### PR TITLE
Upgrade to newer svg2ttf (currently at 4.0.1). 

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
     "unicode"
   ],
   "dependencies": {
-    "ttf2woff": "~1.2.0",
-    "svg2ttf": "~1.1.2",
-    "svgo": "~0.4.4",
-    "xml2js": "~0.4.1",
     "async": "~0.2.9",
+    "svg2ttf": "^4.0.1",
+    "svgo": "~0.4.4",
+    "svgpath": "~1.0.2",
+    "ttf2woff": "~1.2.0",
     "underscore": "~1.5.2",
-    "svgpath": "~1.0.2"
+    "xml2js": "~0.4.1"
   },
   "devDependencies": {},
   "engines": {


### PR DESCRIPTION
There were issues with empty glyph generation in the old version (the previous verson of the project used the fairly archaic 1.x version). This fixes it out of the box :)